### PR TITLE
add daily/weakly automatic reset support

### DIFF
--- a/src/lib/reset-util.ts
+++ b/src/lib/reset-util.ts
@@ -1,0 +1,61 @@
+import type Task from "./components/todo/data/ITask";
+import tasks from "./components/todo/data/tasks";
+
+const LS_TIME_KEY = "last-visit-time";
+const DAY_IN_MILLIS = 24 * 60 * 60 * 1000;
+
+const lastVisitDate = () => {
+  const persistedDate = window.localStorage.getItem(LS_TIME_KEY);
+  return new Date(persistedDate ?? 0);
+};
+
+const dailyResetDate = (ref: Date) => {
+  const date = new Date(ref);
+  date.setUTCHours(10, 0, 0, 0);
+  return date;
+};
+
+const weeklyResetDate = (ref: Date) => {
+  const date = dailyResetDate(ref);
+  const thursday = 4; // thursday is the 4th day of the week.
+  const currentDay = date.getUTCDay();
+  const reamingMillis = (thursday - currentDay) * DAY_IN_MILLIS;
+  date.setUTCMilliseconds(date.getUTCMilliseconds() + reamingMillis);
+  return date;
+};
+
+const shouldResetDaily = () => {
+  const now = new Date();
+  const lastVisit = lastVisitDate();
+  return lastVisit < dailyResetDate(now) && now > dailyResetDate(lastVisit);
+};
+
+const shouldResetWeakly = () => {
+  const now = new Date();
+  const lastVisit = lastVisitDate();
+  return lastVisit < weeklyResetDate(now) && now > weeklyResetDate(lastVisit);
+};
+
+const reset = (tasksToReset: Task[]) => {
+  tasksToReset.forEach(({ title }) => {
+    const key = `${title.toLocaleLowerCase().split(" ").join("-")}-checkbox`;
+    window.localStorage.removeItem(key);
+  });
+};
+
+const resetDaily = (force = false) => {
+  return force
+    ? reset(tasks.dailies)
+    : shouldResetDaily() && reset(tasks.dailies);
+};
+
+const resetWeakly = (force = false) => {
+  return force
+    ? reset(tasks.weeklies)
+    : shouldResetWeakly() && reset(tasks.weeklies);
+};
+const updateLastVisit = () => {
+  window.localStorage.setItem(LS_TIME_KEY, new Date().toJSON());
+};
+
+export { resetDaily, resetWeakly, updateLastVisit };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,8 +7,15 @@ import defaultSEOConfig from "../../next-seo.config";
 import { Chakra } from "Chakra";
 import Layout from "lib/layout";
 import "lib/styles/globals.css";
+import { resetDaily, resetWeakly, updateLastVisit } from "lib/reset-util";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
+  if (typeof window !== "undefined") {
+    resetDaily();
+    resetWeakly();
+    updateLastVisit();
+  }
+
   return (
     <Chakra cookies={pageProps.cookies}>
       <Head>


### PR DESCRIPTION
This PR adds automatic reset support.

I think all regions are reset at 10:00 UTC.

I'm live in Turkey and reset time is 13:00 GMT+3. The person who I ask on Reddit said NAE server reset time is 06:00 EST.

This [website](https://www.worldtimebuddy.com/est-to-utc-converter) shows EST to UTC with your current timezone and this is support my idea.

If you don't like the naming, folder structure or something else please tell I will fix it.